### PR TITLE
feat: modernize layout with sidebar workspace

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,18 +1,18 @@
 /* CSS Variables for theming */
 :root {
-    --primary-color: #2563eb;
-    --secondary-color: #64748b;
-    --success-color: #059669;
-    --danger-color: #dc2626;
-    --warning-color: #d97706;
-    --info-color: #0891b2;
-    --light-bg: #f8fafc;
-    --dark-bg: #1e293b;
-    --border-color: #e2e8f0;
-    --text-primary: #1e293b;
-    --text-secondary: #64748b;
-    --shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-    --radius: 8px;
+    --primary-color: #4f46e5;
+    --secondary-color: #6b7280;
+    --success-color: #10b981;
+    --danger-color: #ef4444;
+    --warning-color: #f59e0b;
+    --info-color: #0ea5e9;
+    --light-bg: #f3f4f6;
+    --dark-bg: #1f2937;
+    --border-color: #e5e7eb;
+    --text-primary: #1f2937;
+    --text-secondary: #6b7280;
+    --shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    --radius: 12px;
 }
 
 * {
@@ -22,9 +22,9 @@
 }
 
 body {
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: #1e293b;
+    font-family: 'Poppins', -apple-system, BlinkMacSystemFont, sans-serif;
+    background: var(--light-bg);
+    color: var(--text-primary);
     min-height: 100vh;
 }
 
@@ -36,9 +36,9 @@ body {
 
 /* Header Styles */
 .app-header {
-    background: rgba(255, 255, 255, 0.95);
-    backdrop-filter: blur(10px);
+    background: #ffffff;
     border-bottom: 1px solid var(--border-color);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
     padding: 1rem 0;
     position: sticky;
     top: 0;
@@ -71,21 +71,42 @@ body {
 /* Main Layout */
 .app-main {
     flex: 1;
+    display: flex;
+    justify-content: center;
+    padding: 0;
+}
+
+.layout-container {
+    flex: 1;
+    display: flex;
     max-width: 1400px;
-    margin: 0 auto;
-    padding: 2rem;
-    display: grid;
-    grid-template-columns: 300px 1fr 350px;
+}
+
+.sidebar {
+    width: 300px;
+    background: #ffffff;
+    border-right: 1px solid var(--border-color);
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
     gap: 1.5rem;
-    min-height: calc(100vh - 100px);
+    overflow-y: auto;
+}
+
+.workspace {
+    flex: 1;
+    padding: 1.5rem;
+    background: var(--light-bg);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
 }
 
 /* Panel Styles */
 .source-panel,
 .preview-panel,
 .settings-panel {
-    background: rgba(255, 255, 255, 0.95);
-    backdrop-filter: blur(10px);
+    background: #ffffff;
     border-radius: var(--radius);
     border: 1px solid var(--border-color);
     box-shadow: var(--shadow);
@@ -98,7 +119,7 @@ body {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    background: var(--light-bg);
+    background: #f9fafb;
 }
 
 .panel-header h2 {
@@ -760,19 +781,16 @@ input[type="color"] {
 }
 
 /* Responsive Design */
-@media (max-width: 1200px) {
-    .app-main {
-        grid-template-columns: 1fr;
-        gap: 1rem;
+@media (max-width: 1024px) {
+    .layout-container {
+        flex-direction: column;
     }
 
-    .source-panel,
-    .settings-panel {
+    .sidebar {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid var(--border-color);
         order: 2;
-    }
-
-    .preview-panel {
-        order: 1;
     }
 }
 
@@ -783,7 +801,11 @@ input[type="color"] {
         gap: 1rem;
     }
 
-    .app-main {
+    .workspace {
+        padding: 1rem;
+    }
+
+    .sidebar {
         padding: 1rem;
     }
 

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/components.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
     <div id="app">
@@ -31,221 +31,227 @@
 
         <!-- Main Content -->
         <main class="app-main">
-            <!-- Left Panel - Source Images -->
-            <section class="source-panel">
-                <div class="panel-header">
-                    <h2><i class="fas fa-images"></i> Source Images</h2>
-                    <button id="clearSourceBtn" class="btn btn-sm btn-danger">Clear All</button>
-                </div>
-                
-                <div class="upload-area" id="sourceUpload">
-                    <div class="upload-content">
-                        <i class="fas fa-cloud-upload-alt"></i>
-                        <p>Drag & drop images here or click to browse</p>
-                        <p class="upload-hint">Supports: JPG, PNG, BMP, TIFF, WebP</p>
-                    </div>
-                    <input type="file" id="sourceInput" multiple accept="image/*" hidden>
-                </div>
-
-                <div class="source-list" id="sourceList">
-                    <!-- Source images will be populated here -->
-                </div>
-            </section>
-
-            <!-- Center Panel - Preview & Controls -->
-            <section class="preview-panel">
-                <div class="preview-header">
-                    <h2><i class="fas fa-eye"></i> Preview</h2>
-                    <div class="preview-controls">
-                        <button id="zoomInBtn" class="btn btn-sm"><i class="fas fa-search-plus"></i></button>
-                        <button id="zoomOutBtn" class="btn btn-sm"><i class="fas fa-search-minus"></i></button>
-                        <button id="fitToScreenBtn" class="btn btn-sm"><i class="fas fa-expand-arrows-alt"></i></button>
-                        <span id="zoomLevel">100%</span>
-                    </div>
-                </div>
-
-                <div class="canvas-container">
-                    <canvas id="previewCanvas" width="800" height="600"></canvas>
-                    <div class="canvas-overlay">
-                        <div class="loading-spinner" id="loadingSpinner" style="display: none;">
-                            <i class="fas fa-spinner fa-spin"></i>
-                            <p>Processing...</p>
+            <div class="layout-container">
+                <aside class="sidebar">
+                    <!-- Left Panel - Source Images -->
+                    <section class="source-panel">
+                        <div class="panel-header">
+                            <h2><i class="fas fa-images"></i> Source Images</h2>
+                            <button id="clearSourceBtn" class="btn btn-sm btn-danger">Clear All</button>
                         </div>
-                    </div>
-                </div>
 
-                <!-- Batch Processing Controls -->
-                <div class="batch-controls">
-                    <button id="previewBatchBtn" class="btn btn-primary btn-lg">
-                        <i class="fas fa-search"></i> Preview Batch
-                    </button>
-                    <button id="processBatchBtn" class="btn btn-success btn-lg" disabled>
-                        <i class="fas fa-play"></i> Process All Images
-                    </button>
-                    <button id="downloadAllBtn" class="btn btn-info btn-lg" disabled>
-                        <i class="fas fa-download"></i> Download All
-                    </button>
-                </div>
+                        <div class="upload-area" id="sourceUpload">
+                            <div class="upload-content">
+                                <i class="fas fa-cloud-upload-alt"></i>
+                                <p>Drag & drop images here or click to browse</p>
+                                <p class="upload-hint">Supports: JPG, PNG, BMP, TIFF, WebP</p>
+                            </div>
+                            <input type="file" id="sourceInput" multiple accept="image/*" hidden>
+                        </div>
 
-                <!-- Progress Bar -->
-                <div class="progress-container" id="progressContainer" style="display: none;">
-                    <div class="progress-bar">
-                        <div class="progress-fill" id="progressFill"></div>
-                    </div>
-                    <div class="progress-text">
-                        <span id="progressText">Processing...</span>
-                        <span id="progressPercent">0%</span>
-                    </div>
-                </div>
-            </section>
+                        <div class="source-list" id="sourceList">
+                            <!-- Source images will be populated here -->
+                        </div>
+                    </section>
 
-            <!-- Right Panel - Watermark Settings -->
-            <section class="settings-panel">
-                <div class="panel-header">
-                    <h2><i class="fas fa-cog"></i> Watermark Settings</h2>
-                </div>
+                    <!-- Right Panel - Watermark Settings -->
+                    <section class="settings-panel">
+                        <div class="panel-header">
+                            <h2><i class="fas fa-cog"></i> Watermark Settings</h2>
+                        </div>
 
-                <!-- Watermark Type Selection -->
-                <div class="setting-group">
-                    <label class="setting-label">Watermark Type</label>
-                    <div class="watermark-type-tabs">
-                        <button class="tab-btn active" data-type="text">
-                            <i class="fas fa-font"></i> Text
-                        </button>
-                        <button class="tab-btn" data-type="image">
-                            <i class="fas fa-image"></i> Image
-                        </button>
-                        <button class="tab-btn" data-type="combined">
-                            <i class="fas fa-layer-group"></i> Combined
-                        </button>
-                    </div>
-                </div>
-
-                <!-- Text Watermark Settings -->
-                <div id="textSettings" class="watermark-settings">
-                    <div class="setting-group">
-                        <label for="watermarkText" class="setting-label">Text Content</label>
-                        <textarea id="watermarkText" placeholder="Enter watermark text...">© WatermarkPro 2025</textarea>
-                    </div>
-
-                    <div class="setting-row">
+                        <!-- Watermark Type Selection -->
                         <div class="setting-group">
-                            <label for="textFont" class="setting-label">Font Family</label>
-                            <select id="textFont">
-                                <option value="Arial">Arial</option>
-                                <option value="Helvetica">Helvetica</option>
-                                <option value="Times New Roman">Times New Roman</option>
-                                <option value="Georgia">Georgia</option>
-                                <option value="Verdana">Verdana</option>
-                                <option value="Impact">Impact</option>
+                            <label class="setting-label">Watermark Type</label>
+                            <div class="watermark-type-tabs">
+                                <button class="tab-btn active" data-type="text">
+                                    <i class="fas fa-font"></i> Text
+                                </button>
+                                <button class="tab-btn" data-type="image">
+                                    <i class="fas fa-image"></i> Image
+                                </button>
+                                <button class="tab-btn" data-type="combined">
+                                    <i class="fas fa-layer-group"></i> Combined
+                                </button>
+                            </div>
+                        </div>
+
+                        <!-- Text Watermark Settings -->
+                        <div id="textSettings" class="watermark-settings">
+                            <div class="setting-group">
+                                <label for="watermarkText" class="setting-label">Text Content</label>
+                                <textarea id="watermarkText" placeholder="Enter watermark text...">© WatermarkPro 2025</textarea>
+                            </div>
+
+                            <div class="setting-row">
+                                <div class="setting-group">
+                                    <label for="textFont" class="setting-label">Font Family</label>
+                                    <select id="textFont">
+                                        <option value="Arial">Arial</option>
+                                        <option value="Helvetica">Helvetica</option>
+                                        <option value="Times New Roman">Times New Roman</option>
+                                        <option value="Georgia">Georgia</option>
+                                        <option value="Verdana">Verdana</option>
+                                        <option value="Impact">Impact</option>
+                                    </select>
+                                </div>
+                                <div class="setting-group">
+                                    <label for="textSize" class="setting-label">Size</label>
+                                    <input type="range" id="textSize" min="12" max="200" value="48">
+                                    <span id="textSizeValue" class="value-display">48px</span>
+                                </div>
+                            </div>
+
+                            <div class="setting-row">
+                                <div class="setting-group">
+                                    <label for="textColor">Color</label>
+                                    <input type="color" id="textColor" value="#ffffff">
+                                </div>
+                                <div class="setting-group">
+                                    <label for="textOpacity">Opacity</label>
+                                    <input type="range" id="textOpacity" min="0" max="100" value="80">
+                                    <span id="textOpacityValue">80%</span>
+                                </div>
+                            </div>
+
+                            <div class="setting-group">
+                                <label for="textRotation">Rotation</label>
+                                <input type="range" id="textRotation" min="-180" max="180" value="0">
+                                <span id="textRotationValue">0°</span>
+                            </div>
+                        </div>
+
+                        <!-- Image Watermark Settings -->
+                        <div id="imageSettings" class="watermark-settings" style="display: none;">
+                            <div class="setting-group">
+                                <label>Watermark Image</label>
+                                <div class="image-upload-area" id="watermarkUpload">
+                                    <div class="upload-content">
+                                        <i class="fas fa-image"></i>
+                                        <p>Upload watermark image</p>
+                                        <p class="upload-hint">PNG, JPG, SVG, PSD supported</p>
+                                    </div>
+                                    <input type="file" id="watermarkInput" accept="image/*,.psd" hidden>
+                                </div>
+                            </div>
+
+                            <div class="setting-row">
+                                <div class="setting-group">
+                                    <label for="imageScale">Scale</label>
+                                    <input type="range" id="imageScale" min="10" max="200" value="100">
+                                    <span id="imageScaleValue">100%</span>
+                                </div>
+                                <div class="setting-group">
+                                    <label for="imageOpacity">Opacity</label>
+                                    <input type="range" id="imageOpacity" min="0" max="100" value="80">
+                                    <span id="imageOpacityValue">80%</span>
+                                </div>
+                            </div>
+
+                            <div class="setting-group">
+                                <label for="imageRotation">Rotation</label>
+                                <input type="range" id="imageRotation" min="-180" max="180" value="0">
+                                <span id="imageRotationValue">0°</span>
+                            </div>
+                        </div>
+
+                        <!-- Position Settings -->
+                        <div class="setting-group">
+                            <label>Position</label>
+                            <div class="position-grid">
+                                <button class="pos-btn" data-position="top-left"><i class="fas fa-arrow-up"></i><i class="fas fa-arrow-left"></i></button>
+                                <button class="pos-btn" data-position="top-center"><i class="fas fa-arrow-up"></i></button>
+                                <button class="pos-btn" data-position="top-right"><i class="fas fa-arrow-up"></i><i class="fas fa-arrow-right"></i></button>
+                                <button class="pos-btn" data-position="center-left"><i class="fas fa-arrow-left"></i></button>
+                                <button class="pos-btn active" data-position="center"><i class="fas fa-circle"></i></button>
+                                <button class="pos-btn" data-position="center-right"><i class="fas fa-arrow-right"></i></button>
+                                <button class="pos-btn" data-position="bottom-left"><i class="fas fa-arrow-down"></i><i class="fas fa-arrow-left"></i></button>
+                                <button class="pos-btn" data-position="bottom-center"><i class="fas fa-arrow-down"></i></button>
+                                <button class="pos-btn" data-position="bottom-right"><i class="fas fa-arrow-down"></i><i class="fas fa-arrow-right"></i></button>
+                            </div>
+                        </div>
+
+                        <!-- Fine Position Adjustment -->
+                        <div class="setting-row">
+                            <div class="setting-group">
+                                <label for="positionX">X Offset</label>
+                                <input type="range" id="positionX" min="-200" max="200" value="0">
+                                <span id="positionXValue">0px</span>
+                            </div>
+                            <div class="setting-group">
+                                <label for="positionY">Y Offset</label>
+                                <input type="range" id="positionY" min="-200" max="200" value="0">
+                                <span id="positionYValue">0px</span>
+                            </div>
+                        </div>
+
+                        <!-- Output Settings -->
+                        <div class="setting-group">
+                            <label for="outputFormat">Output Format</label>
+                            <select id="outputFormat">
+                                <option value="png">PNG (Recommended)</option>
+                                <option value="jpeg">JPEG</option>
+                                <option value="webp">WebP</option>
                             </select>
                         </div>
-                        <div class="setting-group">
-                            <label for="textSize" class="setting-label">Size</label>
-                            <input type="range" id="textSize" min="12" max="200" value="48">
-                            <span id="textSizeValue" class="value-display">48px</span>
-                        </div>
-                    </div>
 
-                    <div class="setting-row">
                         <div class="setting-group">
-                            <label for="textColor">Color</label>
-                            <input type="color" id="textColor" value="#ffffff">
+                            <label for="outputQuality">Quality</label>
+                            <input type="range" id="outputQuality" min="50" max="100" value="95">
+                            <span id="outputQualityValue">95%</span>
                         </div>
-                        <div class="setting-group">
-                            <label for="textOpacity">Opacity</label>
-                            <input type="range" id="textOpacity" min="0" max="100" value="80">
-                            <span id="textOpacityValue">80%</span>
-                        </div>
-                    </div>
+                    </section>
+                </aside>
 
-                    <div class="setting-group">
-                        <label for="textRotation">Rotation</label>
-                        <input type="range" id="textRotation" min="-180" max="180" value="0">
-                        <span id="textRotationValue">0°</span>
-                    </div>
-                </div>
-
-                <!-- Image Watermark Settings -->
-                <div id="imageSettings" class="watermark-settings" style="display: none;">
-                    <div class="setting-group">
-                        <label>Watermark Image</label>
-                        <div class="image-upload-area" id="watermarkUpload">
-                            <div class="upload-content">
-                                <i class="fas fa-image"></i>
-                                <p>Upload watermark image</p>
-                                <p class="upload-hint">PNG, JPG, SVG, PSD supported</p>
+                <!-- Center Panel - Preview & Controls -->
+                <div class="workspace">
+                    <section class="preview-panel">
+                        <div class="preview-header">
+                            <h2><i class="fas fa-eye"></i> Preview</h2>
+                            <div class="preview-controls">
+                                <button id="zoomInBtn" class="btn btn-sm"><i class="fas fa-search-plus"></i></button>
+                                <button id="zoomOutBtn" class="btn btn-sm"><i class="fas fa-search-minus"></i></button>
+                                <button id="fitToScreenBtn" class="btn btn-sm"><i class="fas fa-expand-arrows-alt"></i></button>
+                                <span id="zoomLevel">100%</span>
                             </div>
-                            <input type="file" id="watermarkInput" accept="image/*,.psd" hidden>
                         </div>
-                    </div>
 
-                    <div class="setting-row">
-                        <div class="setting-group">
-                            <label for="imageScale">Scale</label>
-                            <input type="range" id="imageScale" min="10" max="200" value="100">
-                            <span id="imageScaleValue">100%</span>
+                        <div class="canvas-container">
+                            <canvas id="previewCanvas" width="800" height="600"></canvas>
+                            <div class="canvas-overlay">
+                                <div class="loading-spinner" id="loadingSpinner" style="display: none;">
+                                    <i class="fas fa-spinner fa-spin"></i>
+                                    <p>Processing...</p>
+                                </div>
+                            </div>
                         </div>
-                        <div class="setting-group">
-                            <label for="imageOpacity">Opacity</label>
-                            <input type="range" id="imageOpacity" min="0" max="100" value="80">
-                            <span id="imageOpacityValue">80%</span>
+
+                        <!-- Batch Processing Controls -->
+                        <div class="batch-controls">
+                            <button id="previewBatchBtn" class="btn btn-primary btn-lg">
+                                <i class="fas fa-search"></i> Preview Batch
+                            </button>
+                            <button id="processBatchBtn" class="btn btn-success btn-lg" disabled>
+                                <i class="fas fa-play"></i> Process All Images
+                            </button>
+                            <button id="downloadAllBtn" class="btn btn-info btn-lg" disabled>
+                                <i class="fas fa-download"></i> Download All
+                            </button>
                         </div>
-                    </div>
 
-                    <div class="setting-group">
-                        <label for="imageRotation">Rotation</label>
-                        <input type="range" id="imageRotation" min="-180" max="180" value="0">
-                        <span id="imageRotationValue">0°</span>
-                    </div>
+                        <!-- Progress Bar -->
+                        <div class="progress-container" id="progressContainer" style="display: none;">
+                            <div class="progress-bar">
+                                <div class="progress-fill" id="progressFill"></div>
+                            </div>
+                            <div class="progress-text">
+                                <span id="progressText">Processing...</span>
+                                <span id="progressPercent">0%</span>
+                            </div>
+                        </div>
+                    </section>
                 </div>
-
-                <!-- Position Settings -->
-                <div class="setting-group">
-                    <label>Position</label>
-                    <div class="position-grid">
-                        <button class="pos-btn" data-position="top-left"><i class="fas fa-arrow-up"></i><i class="fas fa-arrow-left"></i></button>
-                        <button class="pos-btn" data-position="top-center"><i class="fas fa-arrow-up"></i></button>
-                        <button class="pos-btn" data-position="top-right"><i class="fas fa-arrow-up"></i><i class="fas fa-arrow-right"></i></button>
-                        <button class="pos-btn" data-position="center-left"><i class="fas fa-arrow-left"></i></button>
-                        <button class="pos-btn active" data-position="center"><i class="fas fa-circle"></i></button>
-                        <button class="pos-btn" data-position="center-right"><i class="fas fa-arrow-right"></i></button>
-                        <button class="pos-btn" data-position="bottom-left"><i class="fas fa-arrow-down"></i><i class="fas fa-arrow-left"></i></button>
-                        <button class="pos-btn" data-position="bottom-center"><i class="fas fa-arrow-down"></i></button>
-                        <button class="pos-btn" data-position="bottom-right"><i class="fas fa-arrow-down"></i><i class="fas fa-arrow-right"></i></button>
-                    </div>
-                </div>
-
-                <!-- Fine Position Adjustment -->
-                <div class="setting-row">
-                    <div class="setting-group">
-                        <label for="positionX">X Offset</label>
-                        <input type="range" id="positionX" min="-200" max="200" value="0">
-                        <span id="positionXValue">0px</span>
-                    </div>
-                    <div class="setting-group">
-                        <label for="positionY">Y Offset</label>
-                        <input type="range" id="positionY" min="-200" max="200" value="0">
-                        <span id="positionYValue">0px</span>
-                    </div>
-                </div>
-
-                <!-- Output Settings -->
-                <div class="setting-group">
-                    <label for="outputFormat">Output Format</label>
-                    <select id="outputFormat">
-                        <option value="png">PNG (Recommended)</option>
-                        <option value="jpeg">JPEG</option>
-                        <option value="webp">WebP</option>
-                    </select>
-                </div>
-
-                <div class="setting-group">
-                    <label for="outputQuality">Quality</label>
-                    <input type="range" id="outputQuality" min="50" max="100" value="95">
-                    <span id="outputQualityValue">95%</span>
-                </div>
-            </section>
+            </div>
         </main>
 
         <!-- Results Panel -->


### PR DESCRIPTION
## Summary
- refactor main layout into sidebar plus workspace for cleaner navigation
- adopt Poppins font and refreshed color palette across the app
- add responsive breakpoints to stack sidebar below workspace on small screens

## Testing
- `npm test` *(fails: sh: 1: open: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f23b442f4832b855e52a14a939366